### PR TITLE
Issue 4 Short Strings Cause an Error

### DIFF
--- a/src/NYSIIS.php
+++ b/src/NYSIIS.php
@@ -187,7 +187,7 @@ class NYSIIS
                 $name,
                 $from,
                 $to,
-                mb_strlen($name) - mb_strlen($from)
+                $this->getPosition($name, $from)
             );
             if ($name !== $translated_name) {
                 break;
@@ -391,7 +391,7 @@ class NYSIIS
                 $name,
                 $from,
                 $to,
-                mb_strlen($name) - mb_strlen($from)
+                $this->getPosition($name, $from)
             );
             if ($name !== $translated_name) {
                 break;
@@ -516,5 +516,20 @@ class NYSIIS
             "Ṵ",
             "Ṳ",
         );
+    }
+    
+    /**
+     * Get the position to start looking for the from string
+     * @param string $name The name to translate
+     * @param string $from The from string we are translating
+     * @return integer
+     */
+    protected function getPosition($name, $from)
+    {
+        $position = mb_strlen($name) - mb_strlen($from);
+        if ($position < 0 || $position > mb_strlen($name)) {
+            $position = mb_strlen($name);
+        }
+        return $position;
     }
 }

--- a/tests/NYSIIS/NYSIISTest.php
+++ b/tests/NYSIIS/NYSIISTest.php
@@ -180,4 +180,31 @@ class NYSIISTest extends \PHPUnit_Framework_TestCase
             }
         }
     }
+    
+    /**
+     * @covers cloudPWR\NYSIIS::encode
+     */
+    public function testShortNames()
+    {
+        $nysiis = new \cloudPWR\NYSIIS();
+        
+        $encode_test = array(
+            "e" => "E",
+            "t" => "T",
+            "a" => "",
+            "o" => "O",
+            "Bo" => "B",
+            "Du" => "D",
+            "Ek" => "EC",
+            "Hu" => "H",
+            "Yu" => "Y",
+        );
+        
+        foreach ($encode_test as $test_name => $expected_encoded) {
+            $this->assertEquals(
+                $expected_encoded,
+                $nysiis->encode($test_name)
+            );
+        }
+    }
 }


### PR DESCRIPTION
* We need to test if the position is valid for the string length. This
only affects very short strings that are shorter than the test string we
need to convert (usually two characters).
* Added a unit test to cover this case.

Issue #4